### PR TITLE
changing how we handle database creation and db hostname creation

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 4.0.3
+version: 4.0.4
 appVersion: v1.88.0
 
 maintainers:

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 4.0.3](https://img.shields.io/badge/Version-4.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.88.0](https://img.shields.io/badge/AppVersion-v1.88.0-informational?style=flat-square)
+![Version: 4.0.4](https://img.shields.io/badge/Version-4.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.88.0](https://img.shields.io/badge/AppVersion-v1.88.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -205,7 +205,6 @@ A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 | nameOverride | string | `""` |  |
 | networkPolicies.enabled | bool | `true` | whether to enable kubernetes network policies or not |
 | postgresql.enabled | bool | `true` | Whether to deploy the stable/postgresql chart with this chart. If disabled, make sure PostgreSQL is available at the hostname below and credentials are configured under postgresql.global.postgresql.auth |
-| postgresql.global.postgresql.auth.database | string | `"matrix"` | name of database to use for matrix |
 | postgresql.global.postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
 | postgresql.global.postgresql.auth.hostname | string | `""` | hostname of db server. Can be left blank if using postgres subchart |
 | postgresql.global.postgresql.auth.password | string | `"changeme"` | password of matrix postgres user - ignored using exsitingSecret |

--- a/charts/matrix/templates/postgresql/initdb-configmap.yaml
+++ b/charts/matrix/templates/postgresql/initdb-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   matrix.sql: |
     CREATE DATABASE matrix ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
-    GRANT ALL PRIVILEGES ON DATABASE {{ .Values.postgresql.global.postgresql.auth.database }} TO {{ .Values.postgresql.global.postgresql.auth.username }};
+    GRANT ALL PRIVILEGES ON DATABASE matrix TO {{ .Values.postgresql.global.postgresql.auth.username }};
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.postgresql.global.postgresql.auth.username }};
   {{- if .Values.bridges.irc.enabled }}
   {{/* Scripts are run in alphabetical order */}}

--- a/charts/matrix/templates/postgresql/initdb-configmap.yaml
+++ b/charts/matrix/templates/postgresql/initdb-configmap.yaml
@@ -7,21 +7,12 @@ metadata:
   {{ include "matrix.labels" . | nindent 4}}
 data:
   matrix.sql: |
-    DROP DATABASE {{ .Values.postgresql.global.postgresql.auth.database }};
-    CREATE DATABASE {{ .Values.postgresql.global.postgresql.auth.database }}
-       ENCODING 'UTF8'
-       LOCALE 'C'
-       TEMPLATE template0
-       OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
+    CREATE DATABASE matrix ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
     GRANT ALL PRIVILEGES ON DATABASE {{ .Values.postgresql.global.postgresql.auth.database }} TO {{ .Values.postgresql.global.postgresql.auth.username }};
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.postgresql.global.postgresql.auth.username }};
   {{- if .Values.bridges.irc.enabled }}
   {{/* Scripts are run in alphabetical order */}}
   zzz_irc.sql: |
-    CREATE DATABASE {{ .Values.bridges.irc.database }}
-       ENCODING 'UTF8'
-       LOCALE 'C'
-       TEMPLATE template0
-       OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
+    CREATE DATABASE {{ .Values.bridges.irc.database }} ENCODING 'UTF8' LOCALE 'C' TEMPLATE template0 OWNER {{ .Values.postgresql.global.postgresql.auth.username }};
   {{- end }}
 {{- end }}

--- a/charts/matrix/templates/synapse/database-secret.yaml
+++ b/charts/matrix/templates/synapse/database-secret.yaml
@@ -15,7 +15,6 @@ metadata:
 type: Opaque
 data:
   {{- if not .Values.postgresql.global.postgresql.auth.existingSecret }}
-  hostname: {{ (include "postgresql.name" .) | b64enc | quote }}
   database: {{ .Values.postgresql.global.postgresql.auth.database | b64enc | quote }}
   username: {{ .Values.postgresql.global.postgresql.auth.username | b64enc | quote }}
   password: {{ .Values.postgresql.global.postgresql.auth.password | b64enc | quote }}

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -46,10 +46,14 @@ spec:
           imagePullPolicy: Always
           env:
             - name: DATABASE_HOSTNAME
+              {{- if .Values.postgresql.enabled }}
+              value: {{ template "postgresql.primary.fullname" .Subcharts.postgresql }}
+              {{ else }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "matrix.postgresql.secretName" . }}
                   key: {{ .Values.postgresql.global.postgresql.auth.secretKeys.databaseHostname }}
+              {{- end }}
             - name: DATABASE
               valueFrom:
                 secretKeyRef:

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -277,8 +277,6 @@ postgresql:
         username: matrix
         # -- password of matrix postgres user - ignored using exsitingSecret
         password: changeme
-        # -- name of database to use for matrix
-        database: matrix
         # -- which port to use to connect to your database server
         port: 5432
         # -- hostname of db server. Can be left blank if using postgres subchart


### PR DESCRIPTION
now if you use the bundled database, we choose the database name for you, but if you use an external database, we still use your existingSecret for database name. This is because we have to accomadate the weird way that synapse requires you to create an initial database. if we let bitnami's postgresql chart create the databsae it creates it with the wrong locale, which should be 'c'.