### PR TITLE
allow registration secret to be existingSecret or auto-generated to create new admins

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 4.1.2
+version: 4.1.3
 appVersion: v1.88.0
 
 maintainers:

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 4.1.2](https://img.shields.io/badge/Version-4.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.88.0](https://img.shields.io/badge/AppVersion-v1.88.0-informational?style=flat-square)
+![Version: 4.1.3](https://img.shields.io/badge/Version-4.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.88.0](https://img.shields.io/badge/AppVersion-v1.88.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -235,7 +235,11 @@ A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 | matrix.registration.allowGuests | bool | `false` | Allow users to join rooms as a guest |
 | matrix.registration.autoJoinRooms | list | `[]` | Rooms to automatically join all new users to |
 | matrix.registration.enabled | bool | `false` | Allow new users to register an account |
+| matrix.registration.existingSecret | string | `""` | if set, pull sharedSecret from an existing k8s secret |
+| matrix.registration.generateSharedSecret | bool | `false` | if set, allows user to generate a random shared secret in a k8s secret ignored if existingSecret is passed in |
 | matrix.registration.requiresToken | bool | `false` | Whether to allow token based registration |
+| matrix.registration.secretKey | string | `"registrationSharedSecret"` | key in existing k8s secret for registration shared secret |
+| matrix.registration.sharedSecret | string | `""` | If set, allows registration of standard or admin accounts by anyone who has the shared secret, even if registration is otherwise disabled. ignored if existingSecret is passed in |
 | matrix.retentionPeriod | string | `"7d"` | How long to keep redacted events in unredacted form in the database |
 | matrix.search | bool | `true` | Set to false to disable message searching |
 | matrix.security.surpressKeyServerWarning | bool | `true` |  |

--- a/charts/matrix/templates/_helpers.tpl
+++ b/charts/matrix/templates/_helpers.tpl
@@ -146,3 +146,14 @@ Helper function to get the coturn secret containing the sharedSecret
 {{ template "matrix.fullname" . }}-coturn-secret
 {{- end }}
 {{- end }}
+
+{{/*
+Helper function to get the registration secret containing the sharedSecret
+*/}}
+{{- define "registration.secretName" -}}
+{{- if .Values.matrix.registration.existingSecret -}}
+{{ .Values.matrix.registration.existingSecret }}
+{{- else if or .Values.matrix.registration.sharedSecret .Values.matrix.registration.generateSharedSecret -}}
+{{ template "matrix.fullname" . }}-registration-secret
+{{- end }}
+{{- end }}

--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -996,13 +996,6 @@ registration_requires_token: {{ .Values.matrix.registration.requiresToken }}
 #
 #enable_3pid_lookup: true
 
-# If set, allows registration of standard or admin accounts by anyone who
-# has the shared secret, even if registration is otherwise disabled.
-#
-{{- if .Values.matrix.registration.sharedSecret }}
-registration_shared_secret: {{ .Values.matrix.registration.sharedSecret }}
-{{- end }}
-
 # Set the number of bcrypt rounds used to generate password hash.
 # Larger numbers increase the work factor needed to generate the hash.
 # The default number is 12 (which equates to 2^12 rounds).

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -95,6 +95,13 @@ spec:
                   name: {{ include "matrix.coturn.secretName" . }}
                   key: {{ .Values.coturn.secretKey }}
             {{- end }}
+            {{- if or .Values.matrix.registration.existingSecret .Values.matrix.registration.sharedSecret .Values.matrix.registration.generateSharedSecret }}
+            - name: REGISTRATION_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "registration.secretName" . }}
+                  key: {{ .Values.matrix.registration.secretKey }}
+            {{- end }}
           command:
             - /bin/sh
             - -ec
@@ -103,6 +110,9 @@ spec:
               cp /initial/{{ .Values.matrix.serverName }}.log.config /data/ && \
               {{- if .Values.coturn.enabled }}
               yq eval -i '.turn_shared_secret = env(COTURN_SHARED_SECRET)' /data/homeserver.yaml && \
+              {{- end }}
+              {{- if or .Values.matrix.registration.existingSecret .Values.matrix.registration.sharedSecret .Values.matrix.registration.generateSharedSecret }}
+              yq eval -i '.registration_shared_secret = env(REGISTRATION_SHARED_SECRET)' /data/homeserver.yaml && \
               {{- end }}
               yq eval -i '.database.args.host = env(DATABASE_HOSTNAME)' /data/homeserver.yaml && \
               yq eval -i '.database.args.database = env(DATABASE)' /data/homeserver.yaml && \

--- a/charts/matrix/templates/synapse/registration_sharedsecret.yaml
+++ b/charts/matrix/templates/synapse/registration_sharedsecret.yaml
@@ -16,9 +16,9 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.matrix.registration.sharedSecret }}
-  registration_shared_secret: {{ .Values.matrix.registration.sharedSecret | b64enc | quote }}
+  registrationSharedSecret: {{ .Values.matrix.registration.sharedSecret | b64enc | quote }}
   {{ else }}
-  registration_shared_secret: {{ randAlphaNum 32 | b64enc | quote }}
+  registrationSharedSecret: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/matrix/templates/synapse/registration_sharedsecret.yaml
+++ b/charts/matrix/templates/synapse/registration_sharedsecret.yaml
@@ -1,0 +1,24 @@
+{{/*
+If set, allows registration of standard or admin accounts by anyone who has the
+shared secret, even if registration is otherwise disabled.
+*/}}
+{{- if not .Values.matrix.registration.existingSecret }}
+{{- if or .Values.matrix.registration.sharedSecret .Values.matrix.registration.generateSharedSecert }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "matrix.fullname" . }}-registration-secret
+  labels:
+    app.kubernetes.io/name: {{ include "matrix.name" . }}
+    helm.sh/chart: {{ include "matrix.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.matrix.registration.sharedSecret }}
+  registration_shared_secret: {{ .Values.matrix.registration.sharedSecret | b64enc | quote }}
+  {{ else }}
+  registration_shared_secret: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -94,10 +94,20 @@ matrix:
     # -- Allow new users to register an account
     enabled: false
 
-    # If set, allows registration of standard or admin accounts by anyone who
+    # -- If set, allows registration of standard or admin accounts by anyone who
     # has the shared secret, even if registration is otherwise disabled.
-    #
-    # sharedSecret: <PRIVATE STRING>
+    # ignored if existingSecret is passed in
+    sharedSecret: ""
+
+    # -- if set, allows user to generate a random shared secret in a k8s secret
+    # ignored if existingSecret is passed in
+    generateSharedSecret: false
+
+    # -- if set, pull sharedSecret from an existing k8s secret
+    existingSecret: ""
+
+    # -- key in existing k8s secret for registration shared secret
+    secretKey: "registrationSharedSecret"
 
     # -- Allow users to join rooms as a guest
     allowGuests: false


### PR DESCRIPTION
adds three new values:

```yaml
matrix:
  # User registration settings
  registration:
    # -- If set, allows registration of standard or admin accounts by anyone who
    # has the shared secret, even if registration is otherwise disabled.
    # ignored if existingSecret is passed in
    sharedSecret: ""

    # -- if set, allows user to generate a random shared secret in a k8s secret
    # ignored if existingSecret is passed in
    generateSharedSecret: false

    # -- if set, pull sharedSecret from an existing k8s secret
    existingSecret: ""

    # -- key in existing k8s secret for registration shared secret
    secretKey: "registrationSharedSecret"
```