### PR TITLE
fix oidc secret typo in _helpers.tpl

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,15 +8,12 @@ sources:
 
 type: application
 
-version: 4.6.0
+version: 4.6.1
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.0
 
 maintainers:
-  - name: "Arkaniad"
-    email: "rhea@isomemetric.com"
-    url: "https://github.com/Arkaniad/"
   - name: "jessebot"
     email: "jessebot@linux.com"
     url: "https://github.com/jessebot/"

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.0](https://img.shields.io/badge/AppVersion-v1.95.0-informational?style=flat-square)
+![Version: 4.6.1](https://img.shields.io/badge/Version-4.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.0](https://img.shields.io/badge/AppVersion-v1.95.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -10,7 +10,6 @@ A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| Arkaniad | <rhea@isomemetric.com> | <https://github.com/Arkaniad/> |
 | jessebot | <jessebot@linux.com> | <https://github.com/jessebot/> |
 
 ## Source Code

--- a/charts/matrix/templates/_helpers.tpl
+++ b/charts/matrix/templates/_helpers.tpl
@@ -1,4 +1,3 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
@@ -159,12 +158,12 @@ Helper function to get the registration secret containing the sharedSecret
 {{- end }}
 
 {{/*
-Helper function to get the registration secret containing the sharedSecret
+Helper function to get the OIDC secret containing the OIDC client id, client secret, and issuer
 */}}
 {{- define "matrix.oidc.secretName" -}}
-{{- if .Values.matrix.odic_config.existingSecret -}}
+{{- if .Values.matrix.oidc_config.existingSecret -}}
 {{ .Values.matrix.oidc_config.existingSecret }}
-{{- else if .Values.matrix.oidc_config.sharedSecret -}}
+{{- else -}}
 {{ template "matrix.fullname" . }}-oidc-secret
 {{- end }}
 {{- end }}


### PR DESCRIPTION
My dyslexia at it again :upside_down_face: There was a typo in the `templates/_helpers.tpl` for `.Values.matrix.oidc_config.existingSecret`. This should be working now. :bow: 

