### PR TITLE
fix oidc templating to actually use all the provided values

### DIFF
--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 4.6.1
+version: 4.6.2
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.0

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 4.6.1](https://img.shields.io/badge/Version-4.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.0](https://img.shields.io/badge/AppVersion-v1.95.0-informational?style=flat-square)
+![Version: 4.6.2](https://img.shields.io/badge/Version-4.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.0](https://img.shields.io/badge/AppVersion-v1.95.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -250,8 +250,10 @@ A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 | matrix.oidc_config.secretKeys.userinfo_endpoint | string | `"userinfo_endpoint"` | key in secret with the userinfo_endpoint if discovery is disabled |
 | matrix.oidc_config.skip_verification | bool | `false` |  |
 | matrix.oidc_config.token_endpoint | string | `"https://accounts.example.com/oauth2/token"` | the oauth2 token endpoint. Required if provider discovery is disabled. |
-| matrix.oidc_config.user_mapping_provider.config.subject_claim | string | `"sub"` | name of the claim containing a unique identifier for user. Defaults to `sub`, which OpenID Connect compliant providers should provide. |
-| matrix.oidc_config.user_mapping_provider.module | string | `"mapping_provider.OidcMappingProvider"` | The custom module's class. Uncomment to use a custom module. Default is 'synapse.handlers.oidc_handler.JinjaOidcMappingProvider'.  github.com/matrix-org/synapse/blob/master/docs/sso_mapping_providers.md#openid-mapping-providers for information on implementing a custom mapping provider. example: module: mapping_provider.OidcMappingProvider |
+| matrix.oidc_config.user_mapping_provider.config.display_name_template | string | `""` |  |
+| matrix.oidc_config.user_mapping_provider.config.localpart_template | string | `""` |  |
+| matrix.oidc_config.user_mapping_provider.config.subject_claim | string | `""` | name of the claim containing a unique identifier for user. Defaults to `sub`, which OpenID Connect compliant providers should provide. |
+| matrix.oidc_config.user_mapping_provider.module | string | `""` | The custom module's class. Uncomment to use a custom module. Default is 'synapse.handlers.oidc_handler.JinjaOidcMappingProvider'.  github.com/matrix-org/synapse/blob/master/docs/sso_mapping_providers.md#openid-mapping-providers for information on implementing a custom mapping provider. example: module: mapping_provider.OidcMappingProvider |
 | matrix.oidc_config.userinfo_endpoint | string | `"https://accounts.example.com/userinfo"` | the OIDC userinfo endpoint. Required if discovery is disabled and the "openid" scope is not requested. |
 | matrix.presence | bool | `true` | Set to false to disable presence (online/offline indicators) |
 | matrix.registration.allowGuests | bool | `false` | Allow users to join rooms as a guest |

--- a/charts/matrix/templates/synapse/_homeserver.yaml
+++ b/charts/matrix/templates/synapse/_homeserver.yaml
@@ -1539,7 +1539,9 @@ oidc_config:
     # See https://github.com/matrix-org/synapse/blob/master/docs/sso_mapping_providers.md#openid-mapping-providers
     # for information on implementing a custom mapping provider.
     #
+    {{- if .Values.matrix.oidc_config.user_mapping_provider.module }}
     module: {{ .Values.matrix.oidc_config.user_mapping_provider.module }} 
+    {{- end }}
 
     # Custom configuration values for the module. This section will be passed as
     # a Python dictionary to the user mapping provider module's `parse_config`
@@ -1552,8 +1554,9 @@ oidc_config:
       # name of the claim containing a unique identifier for the user.
       # Defaults to `sub`, which OpenID Connect compliant providers should provide.
       #
-      #subject_claim: "sub"
-
+      {{- if .Values.matrix.oidc_config.user_mapping_provider.config.subject_claim }}
+      subject_claim: {{ .Values.matrix.oidc_config.user_mapping_provider.config.subject_claim }}
+      {{- end }}
       # Jinja2 template for the localpart of the MXID.
       #
       # When rendering, this template is given the following variables:
@@ -1561,13 +1564,15 @@ oidc_config:
       #     Token
       #
       # This must be configured if using the default mapping provider.
-      #
-      {{/*      localpart_template: "{{ user.preferred_username }}"*/}}
+      {{- if .Values.matrix.oidc_config.user_mapping_provider.config.localpart_template }}
+      localpart_template: {{ .Values.matrix.oidc_config.user_mapping_provider.config.localpart_template }}
+      {{- end }}
+
+      {{- if .Values.matrix.oidc_config.user_mapping_provider.config.display_name_template }}
       # Jinja2 template for the display name to set on first login.
-      #
       # If unset, no displayname will be set.
-      #
-      {{/*      #display_name_template: "{{ user.given_name }} {{ user.last_name }}"*/}}
+      display_name_template: {{ .Values.matrix.oidc_config.user_mapping_provider.config.display_name_template }}
+      {{- end }}
   {{- end }}
 
 

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -207,6 +207,9 @@ spec:
           command:
             - |
               pip install synapse-s3-storage-provider
+              {{- if .Values.matrix.oidc_config.user_mapping_provider.module }}
+              pip install {{ .Values.matrix.oidc_config.user_mapping_provider.module }}
+              {{- end }}
           {{- end }}
           env:
             {{- if .Values.synapse.securityContext.env }}

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -203,7 +203,7 @@ matrix:
       # for information on implementing a custom mapping provider.
       # example:
       # module: mapping_provider.OidcMappingProvider
-      module: mapping_provider.OidcMappingProvider
+      module: ""
 
       # Custom configuration values for the module. This section will be passed as
       # a Python dictionary to the user mapping provider module's `parse_config`
@@ -215,7 +215,12 @@ matrix:
       config:
         # -- name of the claim containing a unique identifier for user. Defaults
         # to `sub`, which OpenID Connect compliant providers should provide.
-        subject_claim: "sub"
+        subject_claim: ""
+        # This must be configured if using the default mapping provider.
+        localpart_template: ""
+        # Jinja2 template for the display name to set on first login.
+        # If unset, no displayname will be set.
+        display_name_template: ""
 
   # Settings for the URL preview crawler
   urlPreviews:


### PR DESCRIPTION
We now accept all of these values:
- `matrix.oidc_config.user_mapping_provider.module`
- `matrix.oidc_config.user_mapping_provider.config.display_name_template`
- `matrix.oidc_config.user_mapping_provider.config.localpart_template`
- `matrix.oidc_config.user_mapping_provider.config.subject_claim`

Previously, they were in the values.yaml but not always correctly inserted into homeserver.yaml

We also install the python module you select in the deployment if provided.