### PR TITLE
allow SMTP credentials from an existing k8s secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ helm install my-release-name matrix --values values.yaml
 - [Bitnami PostgreSQL subchart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) to deploy a cluster - needs some work to standardize though, so we also support external postgresql servers
 - [Coturn TURN server subchart](https://github.com/jessebot/coturn-chart) for VoIP calls
 - Use [s3 to store stuff](https://github.com/matrix-org/synapse-s3-storage-provider/tree/main)
+- Use an existing Kubernetes Secret for an external mail server for email notifications
 
 #### ⚠️ Optional Features (Untested Since Fork)
 
-These features still need to be tested, but are technically baked into the chart:
+These features still need to be tested, but are technically baked into the chart from the fork:
 
-- Choice of lightweight Exim relay or external mail server for email notifications
+- Use of lightweight Exim relay
 - [Half-Shot/matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord) Discord bridge
 - [matrix-org/matrix-appservice-irc](https://github.com/matrix-org/matrix-appservice-irc) IRC bridge
 - [tulir/mautrix-whatsapp](https://github.com/tulir/mautrix-whatsapp) WhatsApp bridge
@@ -42,4 +43,4 @@ Working on full stability, but always happy to receive GitHub Issues or PRs 💙
 
 This chart is now maintained mostly by me, @jessebot, but I'd love contributors as well! My goal is to provide regular updates using dependabot (maybe renovatebot soon) and provide some level of basic security from a k8s perspective. The aim as of right now has been removing any plaintext secrets and allowing for existing PVCs. I'm also trying to standardize the chart more by following predictable values.yaml patterns.
 
-Note: I may stop supporting this if a larger entity maintains a better matrix chart (e.g. Bitnami releases a matrix helm chart), as then I'll just write PRs directly to them. At that time I'll put in a note in this README before publically archiving the repo. As of right now though, in October 2023, there are no other actively maintained matrix helm charts for matrix that meet all my needs or are regularly updated to justify creating PRs.
+Note: I may stop supporting this if a larger entity maintains a better matrix chart (e.g. Bitnami releases a matrix helm chart), as then I'll just write PRs directly to them. At that time I'll put in a note in this README before publicly archiving the repo. As of right now though, in October 2023, there are no other actively maintained matrix helm charts for matrix that meet all my needs or are regularly updated to justify creating PRs.

--- a/charts/matrix/Chart.yaml
+++ b/charts/matrix/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 
 type: application
 
-version: 4.7.0
+version: 4.7.1
 
 # renovate: image=matrixdotorg/synapse
 appVersion: v1.95.0

--- a/charts/matrix/README.md
+++ b/charts/matrix/README.md
@@ -1,6 +1,6 @@
 # matrix
 
-![Version: 4.7.0](https://img.shields.io/badge/Version-4.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.0](https://img.shields.io/badge/AppVersion-v1.95.0-informational?style=flat-square)
+![Version: 4.7.1](https://img.shields.io/badge/Version-4.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.95.0](https://img.shields.io/badge/AppVersion-v1.95.0-informational?style=flat-square)
 
 A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 
@@ -193,11 +193,13 @@ A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 | imagePullSecrets | list | `[]` |  |
 | mail.elementUrl | string | `""` | Optional: Element instance URL. If ingress is enabled, this is unnecessary, else if this is empty, emails will contain a link to https://app.element.io |
 | mail.enabled | bool | `false` | disabled all email notifications by default. NOTE: If enabled, either enable the Exim relay or configure an external mail server below |
-| mail.external.host | string | `""` | External mail server hostname |
-| mail.external.password | string | `""` | External mail server password |
-| mail.external.port | int | `25` | External mail server port |
-| mail.external.requireTransportSecurity | bool | `true` |  |
-| mail.external.username | string | `""` | External mail server username |
+| mail.external.existingSecret | string | `""` | use an existing k8s Secret for your host, username, and password |
+| mail.external.host | string | `""` | External mail server hostname - ignored if existingSecret not "" |
+| mail.external.password | string | `""` | External mail server password - ignored if existingSecret not "" |
+| mail.external.port | int | `587` | External mail server port INSECURE: 25, SSL: 465, STARTTLS: 587 |
+| mail.external.requireTransportSecurity | bool | `true` | require TLS, I think |
+| mail.external.secretKeys | object | `{"host":"host","password":"password","username":"username"}` | secret keys to use for your existing SMTP server |
+| mail.external.username | string | `""` | External mail server username - ignored if existingSecret not "" |
 | mail.from | string | `"Matrix <matrix@example.com>"` | Name and email address for outgoing mail |
 | mail.relay.enabled | bool | `true` | whether to enable exim relay or not |
 | mail.relay.image.pullPolicy | string | `"IfNotPresent"` |  |
@@ -233,7 +235,7 @@ A Helm chart to deploy a Matrix homeserver stack into Kubernetes
 | matrix.logging.synapseLogLevel | string | `"WARNING"` | The log level for the synapse server |
 | matrix.oidc.enabled | bool | `false` | set to true to enable authorization against an OpenID Connect server |
 | matrix.oidc.existingSecret | string | `""` | existing secret to use for the OIDC config |
-| matrix.oidc.providers | list | `[{"authorization_endpoint":"https://accounts.example.com/oauth2/auth","backchannel_logout_enabled":true,"client_auth_method":"client_secret_post","client_id":"provided-by-your-issuer","client_secret":"provided-by-your-issuer","discover":true,"idp_brand":"","idp_id":"","idp_name":"","issuer":"https://accounts.example.com/","scopes":["openid","profile"],"skip_verification":false,"token_endpoint":"https://accounts.example.com/oauth2/token","user_mapping_provider":{"config":{"display_name_template":"","localpart_template":"","picture_template":"{{ user.data.profile_image_url }}","subject_claim":""}},"userinfo_endpoint":"https://accounts.example.com/userinfo"}]` | each of these will be templated under oidc_providers in homeserver.yaml ref: https://matrix-org.github.io/synapse/latest/openid.html?search=  |
+| matrix.oidc.providers | list | `[{"authorization_endpoint":"https://accounts.example.com/oauth2/auth","backchannel_logout_enabled":true,"client_auth_method":"client_secret_post","client_id":"provided-by-your-issuer","client_secret":"provided-by-your-issuer","discover":true,"idp_brand":"","idp_id":"","idp_name":"","issuer":"https://accounts.example.com/","scopes":["openid","profile"],"skip_verification":false,"token_endpoint":"https://accounts.example.com/oauth2/token","user_mapping_provider":{"config":{"display_name_template":"","localpart_template":"","picture_template":"{{ user.data.profile_image_url }}","subject_claim":""}},"userinfo_endpoint":"https://accounts.example.com/userinfo"}]` | each of these will be templated under oidc_providers in homeserver.yaml ref: https://matrix-org.github.io/synapse/latest/openid.html?search= |
 | matrix.oidc.providers[0] | object | `{"authorization_endpoint":"https://accounts.example.com/oauth2/auth","backchannel_logout_enabled":true,"client_auth_method":"client_secret_post","client_id":"provided-by-your-issuer","client_secret":"provided-by-your-issuer","discover":true,"idp_brand":"","idp_id":"","idp_name":"","issuer":"https://accounts.example.com/","scopes":["openid","profile"],"skip_verification":false,"token_endpoint":"https://accounts.example.com/oauth2/token","user_mapping_provider":{"config":{"display_name_template":"","localpart_template":"","picture_template":"{{ user.data.profile_image_url }}","subject_claim":""}},"userinfo_endpoint":"https://accounts.example.com/userinfo"}` | id of your identity provider, e.g. dex |
 | matrix.oidc.providers[0].authorization_endpoint | string | `"https://accounts.example.com/oauth2/auth"` | oauth2 authorization endpoint. Required if provider discovery disabled. |
 | matrix.oidc.providers[0].client_auth_method | string | `"client_secret_post"` | auth method to use when exchanging the token. Valid values are: 'client_secret_basic' (default), 'client_secret_post' and 'none'. |

--- a/charts/matrix/templates/synapse/deployment.yaml
+++ b/charts/matrix/templates/synapse/deployment.yaml
@@ -142,6 +142,24 @@ spec:
                   key: {{ .Values.matrix.oidc.secretKeys.userinfo_endpoint }}
             {{- end }}
             {{- end }}
+            {{- if and .Values.mail.enabled .Values.mail.external.existingSecret }}
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mail.external.existingSecret }}
+                  key: {{ .Values.mail.external.secretKeys.host }}
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mail.external.existingSecret }}
+                  key: {{ .Values.mail.external.secretKeys.username }}
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mail.external.existingSecret }}
+                  key: {{ .Values.mail.external.secretKeys.password }}
+
+            {{- end }}
           command:
             - /bin/sh
             - -ec
@@ -172,6 +190,11 @@ spec:
               yq eval -i '.database.args.database = env(DATABASE)' /data/homeserver.yaml && \
               yq eval -i '.database.args.user = env(DATABASE_USERNAME)' /data/homeserver.yaml && \
               yq eval -i '.database.args.password = env(DATABASE_PASSWORD)' /data/homeserver.yaml
+              {{- if and .Values.mail.enabled .Values.mail.external.existingSecret }}
+              yq eval -i '.email.smtp_host = env(SMTP_HOST)' /data/homeserver.yaml
+              yq eval -i '.email.smtp_user = env(SMTP_USER)' /data/homeserver.yaml
+              yq eval -i '.email.smtp_pass = env(SMTP_PASS)' /data/homeserver.yaml
+              {{- end }}
           volumeMounts:
             - name: synapse-initial-config
               mountPath: "/initial"

--- a/charts/matrix/values.yaml
+++ b/charts/matrix/values.yaml
@@ -858,17 +858,25 @@ mail:
     labels:
       component: mail
 
-  # External mail server
+  # External SMTP (mail) server
   external:
-    # -- External mail server hostname
+    # -- External mail server hostname - ignored if existingSecret not ""
     host: ""
-    # -- External mail server port
-    port: 25  # SSL: 465, STARTTLS: 587
-    # -- External mail server username
+    # -- External mail server port INSECURE: 25, SSL: 465, STARTTLS: 587
+    port: 587
+    # -- External mail server username - ignored if existingSecret not ""
     username: ""
-    # -- External mail server password
+    # -- External mail server password - ignored if existingSecret not ""
     password: ""
+    # -- require TLS, I think
     requireTransportSecurity: true
+    # -- use an existing k8s Secret for your host, username, and password
+    existingSecret: ""
+    # -- secret keys to use for your existing SMTP server
+    secretKeys:
+      host: "host"
+      username: "username"
+      password: "password"
 
 bridges:
   irc:


### PR DESCRIPTION
We're finally testing this feature now, and the first thing we noticed was that SMTP credentials were passed in plain text exclusively. Now you can pull the SMTP host, user, and password from an existing k8s secret.